### PR TITLE
Update excon to play nicely with the world

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     xplenty-api (0.1.1)
-      excon (~> 0.20.0)
+      excon (~> 0.58)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    excon (0.20.1)
+    excon (0.62.0)
     minitest (4.7.4)
     rake (10.0.4)
 
@@ -18,3 +18,6 @@ DEPENDENCIES
   minitest
   rake
   xplenty-api!
+
+BUNDLED WITH
+   1.16.3

--- a/lib/xplenty/api/version.rb
+++ b/lib/xplenty/api/version.rb
@@ -1,5 +1,5 @@
 module Xplenty
   class API
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/xplenty.gemspec
+++ b/xplenty.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'excon', '~>0.20.0'
+  s.add_runtime_dependency 'excon', '~> 0.58'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This is an update to get xplenty.rb to use a close to current version of excon so that it will work well with modern gems.

To mitigate any confusion - this is from Wove, previously known as TapFwd.